### PR TITLE
ACTUM-267: Add `/` endpoints for Kubernetes healthchecks

### DIFF
--- a/ci/config/nginx.conf
+++ b/ci/config/nginx.conf
@@ -1,55 +1,59 @@
 events {
-	worker_connections 768;
+  worker_connections 768;
 }
 
 http {
-	##
-	# SSL Settings
-	##
+  ##
+  # SSL Settings
+  ##
 
-	ssl_protocols TLSv1 TLSv1.1 TLSv1.2; # Dropping SSLv3, ref: POODLE
-	ssl_prefer_server_ciphers on;
+  ssl_protocols TLSv1 TLSv1.1 TLSv1.2; # Dropping SSLv3, ref: POODLE
+  ssl_prefer_server_ciphers on;
 
-	##
-	# Logging Settings
-	##
+  ##
+  # Logging Settings
+  ##
 
-	access_log /var/log/nginx/access.log;
-	error_log /var/log/nginx/error.log;
+  access_log /var/log/nginx/access.log;
+  error_log /var/log/nginx/error.log;
 
-	server {
-	    listen 9200;
-	    listen [::]:9200;
+  server {
+    listen 9200;
+    listen [::]:9200;
 
-	    auth_basic                "Elasticsearch auth";
-	    auth_basic_user_file      "/data/nginx/http.passwd";
+    auth_basic                "Elasticsearch auth";
+    auth_basic_user_file      "/data/nginx/http.passwd";
 
-	    location / {
-		    proxy_pass            http://localhost:9201;
-		    proxy_read_timeout    90;
-		    proxy_connect_timeout 90;
-		    proxy_set_header      Host $host;
-		    proxy_set_header      X-Real-IP $remote_addr;
-		    proxy_set_header      X-Forwarded-For $proxy_add_x_forwarded_for;
-		    proxy_set_header      Proxy "";
-		}
-	}
+    location / {
+      proxy_pass            http://localhost:9201;
+      proxy_read_timeout    90;
+      proxy_connect_timeout 90;
+      proxy_set_header      Host $host;
+      proxy_set_header      X-Real-IP $remote_addr;
+      proxy_set_header      X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header      Proxy "";
+    }
+  }
 
-	server {
-	    listen 5601;
-	    listen [::]:5601;
+  server {
+    listen 5601;
+    listen [::]:5601;
 
-	    auth_basic                "Kibana auth";
-	    auth_basic_user_file      "/data/nginx/http.passwd";
+    location / {
+      auth_basic            "Kibana auth";
+      auth_basic_user_file  "/data/nginx/http.passwd";
+      proxy_pass            http://localhost:5602;
+      proxy_read_timeout    90;
+      proxy_connect_timeout 90;
+      proxy_set_header      Host $host;
+      proxy_set_header      X-Real-IP $remote_addr;
+      proxy_set_header      X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header      Proxy "";
+    }
 
-	    location / {
-		    proxy_pass            http://localhost:5602;
-		    proxy_read_timeout    90;
-		    proxy_connect_timeout 90;
-		    proxy_set_header      Host $host;
-		    proxy_set_header      X-Real-IP $remote_addr;
-		    proxy_set_header      X-Forwarded-For $proxy_add_x_forwarded_for;
-		    proxy_set_header      Proxy "";
-		}
-	}
+    location = / {
+      default_type text/html;
+      return 200 "Nginx Online; Redirecting to Kibana... <script>window.location.replace(window.location.origin + '/app/kibana')</script>";
+    }
+  }
 }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -15,6 +15,19 @@ tags:
   - name: System
   - name: Records
 paths:
+  "/":
+    get:
+      tags:
+        - System
+      description: Get the version information for OIP Daemon
+      operationId: root
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/version'
   "/oip/daemon/version":
     get:
       tags:
@@ -27,26 +40,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  BuiltBy:
-                    type: string
-                    example: 'GitLabCI'
-                  BuildDate:
-                    type: string
-                    example: '2020.05.14.153540'
-                  GoVersion:
-                    type: string
-                    example: 'go1.12.4 linux/amd64'
-                  GitCommitHash:
-                    type: string
-                    example: 'b37bf94'
-                  Started:
-                    type: string
-                    example: 'Thu, 14 May 2020 16:07:26 +0000'
-                  Uptime:
-                    type: string
-                    example: '2h6m23.7554745s'
+                $ref: '#/components/schemas/version'
   "/oip/sync/status":
     get:
       tags:
@@ -139,6 +133,27 @@ paths:
         
 components:
   schemas:
+    version:
+      type: object
+      properties:
+        BuiltBy:
+          type: string
+          example: 'GitLabCI'
+        BuildDate:
+          type: string
+          example: '2020.05.14.153540'
+        GoVersion:
+          type: string
+          example: 'go1.12.4 linux/amd64'
+        GitCommitHash:
+          type: string
+          example: 'b37bf94'
+        Started:
+          type: string
+          example: 'Thu, 14 May 2020 16:07:26 +0000'
+        Uptime:
+          type: string
+          example: '2h6m23.7554745s'
     artifactResponse:
       type: object
       properties:


### PR DESCRIPTION
Kubernetes web services require a healthcheck returning a status of `200` to a `GET` on the root `/` endpoint. Previously OIPd would return a 404 and Kibana was a permissioned endpoint. 

# Changelog
## Added
- Added new `/` endpoint to OIPd
## Changed
- Changed kibana `/` endpoint to return `200` and redirect to `/app/kibana` for login.